### PR TITLE
Test through python 3.6 and Django 1.11 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,58 @@
 language: python
-python:
-  - "3.5"
+#python:
+#  - "3.6"
 install:
   - pip install tox
   - pip install -r requirements-test.txt
 script: tox -e $TOX_ENV
-env:
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py27-django-18
-  - TOX_ENV=py35-django-19
-  - TOX_ENV=py34-django-19
-  - TOX_ENV=py27-django-19
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27-django-111
+    - python: 2.7
+      env: TOX_ENV=py27-django-110
+    - python: 2.7
+      env: TOX_ENV=py27-django-19
+    - python: 2.7
+      env: TOX_ENV=py27-django-18
+    - python: 3.4
+      env: TOX_ENV=py34-django-111
+    - python: 3.4
+      env: TOX_ENV=py34-django-110
+    - python: 3.4
+      env: TOX_ENV=py34-django-19
+    - python: 3.4
+      env: TOX_ENV=py34-django-18
+    - python: 3.5
+      env: TOX_ENV=py35-django-111
+    - python: 3.5
+      env: TOX_ENV=py35-django-110
+    - python: 3.5
+      env: TOX_ENV=py35-django-19
+    - python: 3.5
+      env: TOX_ENV=py35-django-18
+    - python: 3.6
+      env: TOX_ENV=py36-django-111
+    - python: 3.6
+      env: TOX_ENV=py36-django-110
+    - python: 3.6
+      env: TOX_ENV=py36-django-19
+    - python: 3.6
+      env: TOX_ENV=py36-django-18
+#env:
+#  - TOX_ENV=py36-django-18
+#  - TOX_ENV=py35-django-18
+#  - TOX_ENV=py34-django-18
+#  - TOX_ENV=py27-django-18
+#  - TOX_ENV=py36-django-19
+#  - TOX_ENV=py35-django-19
+#  - TOX_ENV=py34-django-19
+#  - TOX_ENV=py27-django-19
+#  - TOX_ENV=py36-django-110
+#  - TOX_ENV=py35-django-110
+#  - TOX_ENV=py34-django-110
+#  - TOX_ENV=py27-django-110
+#  - TOX_ENV=py36-django-111
+#  - TOX_ENV=py35-django-111
+#  - TOX_ENV=py34-django-111
+#  - TOX_ENV=py27-django-111

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,18 @@ History
 
 Current
 +++++++++
-
+* add python 3.6 and django 1.11 to tox.ini - still a bit broken
+* convert to matrix for environments in .travis.yml
+  because tox only wants to test py3.6 when installed under 3.6
+  but will not test 3.5 when running with python 3.6 as the base.
+* Remove invalid ROOT_URLCONF from test django config
+  There is no urls.py for djfractions, don't tell it to use one.  Older
+  django versions were ok with this, but 1.11 is pickier about the correctness.
+* add current changes to HISTORY.rst
+* Adjust SILENCED_SYSTEM_CHECKS setting during tests
+  Django 1.11 is stricter about system checks and will not even run
+  the tests where there are some errors we specifically test for due
+  to older django versions letting you make these mistakes.
 
 1.0.0 (2016.12-31)
 ++++++++++++++++++

--- a/runtests.py
+++ b/runtests.py
@@ -5,6 +5,15 @@ try:
     from django.test.utils import get_runner
 
     settings.configure(
+        # Disable some system checks during tests for now
+        # Django 1.11 appears to have gotten more strict about these
+        # and now tests do not run, but since some older, supported
+        # versions do not enforce them with the systemcheck system
+        # there are tests which specifically make these mistakes and ensure
+        # that the correct exceptions are raised.
+        # fields.E130 = must define decimal_places
+        # fields.E132 = must define max_digits
+        SILENCED_SYSTEM_CHECKS = ['fields.E130', 'fields.E132'],
         DEBUG=True,
         USE_TZ=True,
         DATABASES={
@@ -12,7 +21,6 @@ try:
                 "ENGINE": "django.db.backends.sqlite3",
             }
         },
-        ROOT_URLCONF="djfractions.urls",
         INSTALLED_APPS=[
             "django.contrib.auth",
             "django.contrib.contenttypes",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist = 
-    {py27,py34,py35}-django-18
-    {py27,py34,py35}-django-19
-    {py27,py34,py35}-django-110
+    {py27,py34,py35,py36}-django-18
+    {py27,py34,py35,py36}-django-19
+    {py27,py34,py35,py36}-django-110
+    {py27,py34,py35,py36}-django-111
     stats
 
 [testenv]
@@ -13,8 +14,10 @@ deps =
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
+    django-111: Django>=1.11,<1.12
     -r{toxinidir}/requirements-test.txt
 basepython =
+    py36: python3.6
     py35: python3.5
     py34: python3.4
     py27: python2.7


### PR DESCRIPTION
* works on travis ci, but local tox does not play nicely yet
* added python 3.6 and django 1.11 to tox.ini
* converted to matrix for environments in .travis.yml
  because tox only wants to test py3.6 when installed under 3.6
  but will not test 3.5 when running with python 3.6 as the base.
* Removed invalid ROOT_URLCONF from test django config
  There is no urls.py for djfractions, don't tell it to use one.  Older
  django versions were ok with this, but 1.11 is pickier about the correctness.
* Adjusted SILENCED_SYSTEM_CHECKS setting during tests
  Django 1.11 is stricter about system checks and will not even run
  the tests where there are some errors we specifically test for due
  to older django versions letting you make these mistakes.
* Updated HISTORY.rst