### PR TITLE
Updated for Django 3.0 and added ability for blank fields

### DIFF
--- a/djfractions/__init__.py
+++ b/djfractions/__init__.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals, absolute_import, division
-
-__version__ = '1.1.0'
-
+from __future__ import unicode_literals, division, absolute_import
+__version__ = '1.2.0'
 from decimal import Decimal
 import fractions
 import re

--- a/djfractions/forms.py
+++ b/djfractions/forms.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals, absolute_import, division, print_function
 
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core import validators
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 
 from decimal import Decimal, InvalidOperation
@@ -95,7 +93,7 @@ class FractionField(forms.Field):
         if value in validators.EMPTY_VALUES:
             return None
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             # some really lame validation that we do not have a string like "1 1 1/4" because that
             # is not a valid number.
             # these regexes should match fractions such as 1 1/4 and 1/4, with any number
@@ -207,7 +205,7 @@ class DecimalFractionField(FractionField):
         # these regexes should match fractions such as 1 1/4 and 1/4, with any number
         # of spaces between digits and / and any length of actual digits such as
         # 100 1/4 or 1 100/400, etc
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             if not is_number(value) and not self.FRACTION_MATCH.match(value) \
                and not self.MIXED_NUMBER_MATCH.match(value):
                 # this second matches optional whitespace, then a digit, then

--- a/djfractions/forms.py
+++ b/djfractions/forms.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals, division, absolute_import, print_function
+import django
+if django.VERSION[0] < 3:
+	from django.utils import six
+	SIX_OR_STR = six.string_types
+else:
+	SIX_OR_STR = str
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -93,7 +100,7 @@ class FractionField(forms.Field):
         if value in validators.EMPTY_VALUES:
             return None
 
-        if isinstance(value, str):
+        if isinstance(value, SIX_OR_STR):
             # some really lame validation that we do not have a string like "1 1 1/4" because that
             # is not a valid number.
             # these regexes should match fractions such as 1 1/4 and 1/4, with any number

--- a/djfractions/models/__init__.py
+++ b/djfractions/models/__init__.py
@@ -1,5 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, division, absolute_import, print_function
-
 from .fields import DecimalFractionField

--- a/djfractions/models/__init__.py
+++ b/djfractions/models/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals, division, absolute_import
 from .fields import DecimalFractionField

--- a/djfractions/models/fields.py
+++ b/djfractions/models/fields.py
@@ -38,6 +38,8 @@ class DecimalFractionField(Field):
 
         super(DecimalFractionField, self).__init__(verbose_name=verbose_name,
                                                    name=name,
+                                                   blank=blank,
+                                                   null=null,
                                                    **kwargs)
 
     def check(self, **kwargs):

--- a/djfractions/models/fields.py
+++ b/djfractions/models/fields.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals, division, absolute_import, print_function
-
 from django.core import checks
 from django.db import connection
 from django.db.models import DecimalField, Field
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 import decimal
@@ -193,7 +190,7 @@ class DecimalFractionField(Field):
         return "DecimalField"
 
     def _format(self, value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return value
         else:
             return self.format_number(value)

--- a/djfractions/models/fields.py
+++ b/djfractions/models/fields.py
@@ -27,14 +27,14 @@ class DecimalFractionField(Field):
     }
     description = _("Fraction number stored in the database as a Decimal")
 
-    def __init__(self, verbose_name=None, name=None, max_digits=None,
+    def __init__(self, verbose_name=None, name=None, max_digits=None, blank=False, null=False,
                  decimal_places=None, limit_denominator=None, coerce_thirds=True,
                  **kwargs):
         self.limit_denominator = limit_denominator
         self.coerce_thirds = coerce_thirds
 
         # for decimal stuff
-        self.max_digits, self.decimal_places = max_digits, decimal_places
+        self.max_digits, self.decimal_places, self.blank, self.null = max_digits, decimal_places, blank, null
 
         super(DecimalFractionField, self).__init__(verbose_name=verbose_name,
                                                    name=name,

--- a/djfractions/models/fields.py
+++ b/djfractions/models/fields.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals, division, absolute_import, print_function
+import django
+if django.VERSION[0] < 3:
+	from django.utils import six
+	SIX_OR_STR = six.string_types
+else:
+	SIX_OR_STR = str
 
 from django.core import checks
 from django.db import connection
@@ -192,7 +199,7 @@ class DecimalFractionField(Field):
         return "DecimalField"
 
     def _format(self, value):
-        if isinstance(value, str):
+        if isinstance(value, SIX_OR_STR):
             return value
         else:
             return self.format_number(value)

--- a/djfractions/models/fields.py
+++ b/djfractions/models/fields.py
@@ -110,7 +110,7 @@ class DecimalFractionField(Field):
             ]
         return []
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, context=None):
         if value is None:
             return value
 

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Fixes #14
It Will now only import if Django version is older than 3.

I also added the ability to leave the fields blank since I found it annoying that you couldn't do this.

I have **not** tested this with Django 2.x as I have moved all of my projects over to 3.x but I don't see any reason why this wouldn't work.